### PR TITLE
mecabのファイル読み込みをOpenJTalk用に変更

### DIFF
--- a/src/mecab/src/common.h
+++ b/src/mecab/src/common.h
@@ -144,14 +144,11 @@
 #define EXIT_SUCCESS 0
 #endif
 
-/* for Open JTalk
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #define WPATH(path) (MeCab::Utf8ToWide(path).c_str())
 #else
 #define WPATH(path) (path)
 #endif
-*/
-#define WPATH(path) (path)
 
 namespace MeCab {
 class die {


### PR DESCRIPTION
mecabはシステムのファイルパスエンコーディング（windowsならUTF-16）でファイルを読み込みますが、OpenJTalkはUTF-8を想定しているので変換が必要です。
コードを追っていくとその用途のコードがあったので、そちらに切り替えるプルリクエストです。

ref: https://github.com/r9y9/pyopenjtalk/issues/18