### PR TITLE
fix setting pause symbol for non-kana symbol

### DIFF
--- a/src/njd_set_pronunciation/njd_set_pronunciation.c
+++ b/src/njd_set_pronunciation/njd_set_pronunciation.c
@@ -153,6 +153,11 @@ void njd_set_pronunciation(NJD * njd)
             NJDNode_set_read(node, NJD_SET_PRONUNCIATION_TOUTEN);
             NJDNode_set_pron(node, NJD_SET_PRONUNCIATION_TOUTEN);
             NJDNode_set_pos(node, NJD_SET_PRONUNCIATION_KIGOU);
+            NJDNode_set_pos_group1(node, NJD_SET_PRONUNCIATION_TOUTEN_POS_GROUP1);
+            NJDNode_set_pos_group2(node, "*");
+            NJDNode_set_pos_group3(node, "*");
+            NJDNode_set_ctype(node, "*");
+            NJDNode_set_cform(node, "*");
          }
       }
    }

--- a/src/njd_set_pronunciation/njd_set_pronunciation_rule_ascii_for_euc_jp.h
+++ b/src/njd_set_pronunciation/njd_set_pronunciation_rule_ascii_for_euc_jp.h
@@ -446,6 +446,7 @@ static const char *njd_set_pronunciation_symbol_list[] = {
 #define NJD_SET_PRONUNCIATION_MASU_PRON "\xa5\xde\xa5\xb9"
 
 #define NJD_SET_PRONUNCIATION_TOUTEN "\xa1\xa2"
+#define NJD_SET_PRONUNCIATION_TOUTEN_POS_GROUP1 "\xc6\xc9\xc5\xc0"
 
 NJD_SET_PRONUNCIATION_RULE_H_END;
 

--- a/src/njd_set_pronunciation/njd_set_pronunciation_rule_ascii_for_shift_jis.h
+++ b/src/njd_set_pronunciation/njd_set_pronunciation_rule_ascii_for_shift_jis.h
@@ -446,6 +446,7 @@ static const char *njd_set_pronunciation_symbol_list[] = {
 #define NJD_SET_PRONUNCIATION_MASU_PRON "\x83\x7d\x83\x58"
 
 #define NJD_SET_PRONUNCIATION_TOUTEN "\x81\x41"
+#define NJD_SET_PRONUNCIATION_TOUTEN_POS_GROUP1 "\x93\xc7\x93\x5f"
 
 NJD_SET_PRONUNCIATION_RULE_H_END;
 

--- a/src/njd_set_pronunciation/njd_set_pronunciation_rule_ascii_for_utf_8.h
+++ b/src/njd_set_pronunciation/njd_set_pronunciation_rule_ascii_for_utf_8.h
@@ -446,6 +446,7 @@ static const char *njd_set_pronunciation_symbol_list[] = {
 #define NJD_SET_PRONUNCIATION_MASU_PRON "\xe3\x83\x9e\xe3\x82\xb9"
 
 #define NJD_SET_PRONUNCIATION_TOUTEN "\xe3\x80\x81"
+#define NJD_SET_PRONUNCIATION_TOUTEN_POS_GROUP1 "\xe8\xaa\xad\xe7\x82\xb9"
 
 NJD_SET_PRONUNCIATION_RULE_H_END;
 

--- a/src/njd_set_pronunciation/njd_set_pronunciation_rule_euc_jp.h
+++ b/src/njd_set_pronunciation/njd_set_pronunciation_rule_euc_jp.h
@@ -446,6 +446,7 @@ static const char *njd_set_pronunciation_symbol_list[] = {
 #define NJD_SET_PRONUNCIATION_MASU_PRON "マス"
 
 #define NJD_SET_PRONUNCIATION_TOUTEN "、"
+#define NJD_SET_PRONUNCIATION_TOUTEN_POS_GROUP1 "読点"
 
 NJD_SET_PRONUNCIATION_RULE_H_END;
 

--- a/src/njd_set_pronunciation/njd_set_pronunciation_rule_shift_jis.h
+++ b/src/njd_set_pronunciation/njd_set_pronunciation_rule_shift_jis.h
@@ -446,6 +446,7 @@ static const char *njd_set_pronunciation_symbol_list[] = {
 #define NJD_SET_PRONUNCIATION_MASU_PRON "マス"
 
 #define NJD_SET_PRONUNCIATION_TOUTEN "、"
+#define NJD_SET_PRONUNCIATION_TOUTEN_POS_GROUP1 "読点"
 
 NJD_SET_PRONUNCIATION_RULE_H_END;
 

--- a/src/njd_set_pronunciation/njd_set_pronunciation_rule_utf_8.h
+++ b/src/njd_set_pronunciation/njd_set_pronunciation_rule_utf_8.h
@@ -446,6 +446,7 @@ static const char *njd_set_pronunciation_symbol_list[] = {
 #define NJD_SET_PRONUNCIATION_MASU_PRON "マス"
 
 #define NJD_SET_PRONUNCIATION_TOUTEN "、"
+#define NJD_SET_PRONUNCIATION_TOUTEN_POS_GROUP1 "読点"
 
 NJD_SET_PRONUNCIATION_RULE_H_END;
 


### PR DESCRIPTION
Maybe this is more of a problem with the dictionary...

`njd_set_pronunciation` sets `read`, `pron` and other features for symbols with 0 mora size.  Specifically, non-kana symbols will be set as `読点`. 

In the following example, `～` is incorrectly parsed as `名詞` using MeCab and naist-jdic (whereas it should be `助詞`). 

```bash
1933年～1937年
1933	名詞,数,*,*,*,*,*
年	名詞,接尾,助数詞,*,*,*,年,ネン,ネン,1/2,C3
～	名詞,サ変接続,*,*,*,*,*
1937	名詞,数,*,*,*,*,*
年	名詞,接尾,助数詞,*,*,*,年,ネン,ネン,1/2,C3

```

Since its mora size is 0, its `read`, `pron` are set to `、` and `pos` is set to `記号`.  Consequently, its features would be the following, which is weird.

```bash
～,記号,サ変接続,*,*,*,*,～,、,、,0,0,*,0
```

So I think `pos_group`, `ctype` and `cform` should also be modified and its features become:

```bash
～,記号,読点,*,*,*,*,～,、,、,0,0,*,0
```






