### PR TITLE
FIX: Fix a warning that occurred when using `pyopenjtalk`.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMake configuration for open_jtalk
 #
 # adapted from https://gist.github.com/hkrn/889259/266e798f48a49d041d7f1e41a579d878134f1fca
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12...3.31)
 
 # set library version
 set(OPEN_JTALK_VERSION 1.11)
@@ -93,21 +93,6 @@ else()
   set(LIB_TYPE STATIC)
 endif()
 
-# find HTSEngine
-find_path(HTS_ENGINE_INCLUDE_DIR HTS_engine.h)
-find_library(HTS_ENGINE_LIB hts_engine_API)
-if(NOT HTS_ENGINE_LIB)
-  # fallback
-  find_library(HTS_ENGINE_LIB HTSEngine)
-endif()
-
-if(HTS_ENGINE_INCLUDE_DIR AND HTS_ENGINE_LIB)
-  target_link_libraries(openjtalk ${HTS_ENGINE_LIB})
-  include_directories(openjtalk ${HTS_ENGINE_INCLUDE_DIR})
-else()
-  message(FATAL_ERROR "Required HTSEngine not found")
-endif()
-
 # configuration for charset
 #option(CHARSET "Encoding set for mecab" "eucjp")
 set(CHARSET "utf8")
@@ -135,6 +120,11 @@ elseif(${CHARSET} STREQUAL "utf8")
   )
 else()
   message(FATAL_ERROR "Encoding ${CHARSET} not recognized. You can set sjis/eucjp/utf8")
+endif()
+
+option(BUILD_PROGRAMS "Build Programs" OFF)
+if(BUILD_PROGRAMS)
+  add_subdirectory(bin)
 endif()
 
 # installation

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -1,0 +1,17 @@
+# find HTSEngine
+find_path(HTS_ENGINE_INCLUDE_DIR HTS_engine.h)
+find_library(HTS_ENGINE_LIB hts_engine_API)
+if(NOT HTS_ENGINE_LIB)
+  # fallback
+  find_library(HTS_ENGINE_LIB HTSEngine)
+endif()
+
+if(NOT HTS_ENGINE_INCLUDE_DIR OR NOT HTS_ENGINE_LIB)
+  message(FATAL_ERROR "Required HTSEngine not found")
+endif()
+
+add_executable(open_jtalk open_jtalk.c)
+set_target_properties(open_jtalk PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(open_jtalk PRIVATE openjtalk "${HTS_ENGINE_LIB}")
+target_include_directories(open_jtalk PRIVATE "${HTS_ENGINE_INCLUDE_DIR}")
+install(TARGETS open_jtalk DESTINATION bin)


### PR DESCRIPTION
Make a correction to prevent the following warning that is displayed when building `pyopenjtalk`.

```
Not searching for unused variables given on the command line.
CMake Deprecation Warning at CMakeLists.txt:5 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

This warning occurs because the cmake you are running does not support the version specified by `cmake_minimum_required()`.

[cmake_minimum_required](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)
> Changed in version 3.31: Compatibility with versions of CMake older than 3.10 is deprecated. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) that do not specify at least 3.10 as their policy version (optionally via ...<max>) will produce a deprecation warning in CMake 3.31 and above.
> 
> Changed in version 3.27: Compatibility with versions of CMake older than 3.5 is deprecated. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce a deprecation warning in CMake 3.27 and above.
> 
> Changed in version 3.19: Compatibility with versions of CMake older than 2.8.12 is deprecated. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) that do not specify at least 2.8.12 as their policy version (optionally via ...<max>) will produce a deprecation warning in CMake 3.19 and above.

[Deprecated and Removed Features](https://cmake.org/cmake/help/latest/release/3.31.html#id14)
> Compatibility with versions of CMake older than 3.10 is now deprecated and will be removed from a future version. Calls to [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) that set the policy version to an older value now issue a deprecation diagnostic.

To prevent this, you need to update your version of `cmake_minimum_required()`.

Also, I found that `target_compile_options()` requires 2.8.12.

[target_compile_options -CMake v2.8.12](https://cmake.org/cmake/help/v2.8.12/cmake.html#command:target_compile_options)
[Commands - CMake v2.8.11](https://cmake.org/cmake/help/v2.8.11/cmake.html#section_Commands)
The CMake v2.8.11 documentation is missing `target_compile_options()`.

Therefore, change it to `cmake_minimum_required(2.8.12...3.21)`.

NOTE: It seems that CMakae v2.6 doesn't even have `add_compile_options`.

---

```
CMake Warning (dev) at CMakeLists.txt:34 (add_library):
  Policy CMP0008 is not set: Libraries linked by full-path must have a valid
  library file name.  Run "cmake --help-policy CMP0008" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  Target "openjtalk" links to item

    D:/a/pyopenjtalk/pyopenjtalk/lib/open_jtalk/src/build/dummy

  which is a full-path but not a valid library file name.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This warning appears to only occur on Windows.
This warning is caused by `pyopenjtalk` passing `-DHTS_ENGINE_LIB=dummy`, a file path that does not exist.
I think this is done because `HTS_ENGINE_LIB` is required in the following part.
https://github.com/r9y9/open_jtalk/blob/7b8e3df9930ae5a73bb943445dbc562804490e73/src/CMakeLists.txt#L96-L109

However, it is `src/bin/open_jtalk.c`, not `openjtalk`, that requires `HTS_Engine`.

In this PR, by adding compiling `open_jtalk.c` as an option, we will also change `HTS_Engine` to become an option.