### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,61 @@
+The Open JTalk is released under the Modified BSD license (see
+http://www.opensource.org/). Using and distributing this software is free
+(without restriction including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of this
+work, and to permit persons to whom this work is furnished to do so) subject to
+the conditions in the following license:
+
+/* ----------------------------------------------------------------- */
+/*           The Japanese TTS System "Open JTalk"                    */
+/*           developed by HTS Working Group                          */
+/*           http://open-jtalk.sourceforge.net/                      */
+/* ----------------------------------------------------------------- */
+/*                                                                   */
+/*  Copyright (c) 2008-2018  Nagoya Institute of Technology          */
+/*                           Department of Computer Science          */
+/*                                                                   */
+/* All rights reserved.                                              */
+/*                                                                   */
+/* Redistribution and use in source and binary forms, with or        */
+/* without modification, are permitted provided that the following   */
+/* conditions are met:                                               */
+/*                                                                   */
+/* - Redistributions of source code must retain the above copyright  */
+/*   notice, this list of conditions and the following disclaimer.   */
+/* - Redistributions in binary form must reproduce the above         */
+/*   copyright notice, this list of conditions and the following     */
+/*   disclaimer in the documentation and/or other materials provided */
+/*   with the distribution.                                          */
+/* - Neither the name of the HTS working group nor the names of its  */
+/*   contributors may be used to endorse or promote products derived */
+/*   from this software without specific prior written permission.   */
+/*                                                                   */
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND            */
+/* CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,       */
+/* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF          */
+/* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE          */
+/* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS */
+/* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,          */
+/* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED   */
+/* TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,     */
+/* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON */
+/* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,   */
+/* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY    */
+/* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE           */
+/* POSSIBILITY OF SUCH DAMAGE.                                       */
+/* ----------------------------------------------------------------- */
+
+Although this software is free, we still offer no warranties and no
+maintenance. We will continue to endeavor to fix bugs and answer queries when
+can, but are not in a position to guarantee it. We will consider consultancy if
+desired, please contacts us for details.
+
+If you are using the Open JTalk in commercial environments, even though no
+license is required, we would be grateful if you let us know as it helps
+justify ourselves to our various sponsors. We also strongly encourage you to
+
+ * refer to the use of Open JTalk in any publications that use this software
+ * report bugs, where possible with bug fixes, that are found
+
+See also three "COPYING" files in "mecab", "mecab-naist-jdic", and the current
+directory for details.


### PR DESCRIPTION
Added LICENSE file from https://sourceforge.net/projects/open-jtalk/files/Open%20JTalk/open_jtalk-1.11/

Feel free to modify or add a license on top of this, but it would be useful to have it in the GitHub repository as well. I saw there is a LICENSE in src/COPYING, but could there also be one for GitHub to detect?